### PR TITLE
addition of the get_memory and set_memory functions

### DIFF
--- a/vasp/getters.py
+++ b/vasp/getters.py
@@ -497,3 +497,29 @@ def get_pseudopotentials(self):
         hashes.append(s.hexdigest())
 
     return zip(symbols, paths, hashes)
+
+
+@monkeypatch_class(vasp.Vasp)
+def get_memory(self):
+    """ Retrieves the recommended memory from the OUTCAR in GB.
+
+    If no OUTCAR exists, or the memory estimate can not be
+    found, return None
+    """
+
+    OUTCAR = os.path.join(self.directory, 'OUTCAR')
+    if os.path.exists(OUTCAR):
+        with open(OUTCAR) as f:
+            lines = f.readlines()
+    else:
+        return None
+
+    for line in lines:
+
+        # There are often two instances of this,
+        # but they  seem to be identical in all cases
+        if 'memory' in line:
+
+            # Return memory estimate in GB
+            required_mem = float(line.split()[-2]) / 1e6
+            return required_mem

--- a/vasp/validate.py
+++ b/vasp/validate.py
@@ -14,9 +14,18 @@ import ase
 from ase.utils import basestring
 import warnings
 
+
 def atoms(calc, val):
     """The Atoms object. (ase.atoms.Atoms or a list of them for an NEB)."""
     assert isinstance(val, ase.atoms.Atoms) or isinstance(val, list)
+
+
+def ediff(calc, val):
+    """EDIFF specifies the global break condition for the electronic loop. (float)
+
+    http://cms.mpi.univie.ac.at/wiki/index.php/EDIFF
+    """
+    assert isinstance(val, float) or val == 0
 
 
 def ediffg(calc, val):

--- a/vasp/writers.py
+++ b/vasp/writers.py
@@ -6,7 +6,6 @@ These are separated out by design to keep vasp.py small. Each function is
 monkey-patched onto the Vasp class as if it were defined in vasp.py.
 
 """
-import json
 import os
 import numpy as np
 import vasp


### PR DESCRIPTION
get_memory() added to getters -- pulls the memory estimate from an existing OUTCAR
set_memory() added to runners -- gets memory from: 1) DB file, 2) existing OUTCAR, or 3) diagnostic run in order of decreasing priority.

*Edit:*
New vaspsum designed to reflect old jaspsum.
Constraints only work for FixAtoms constraints at the moment,

Style is slightly different with better unit documentation and energy output moved closer to the bottom of the string for convenient access on large outputs.

Other future modifications can be found in the doc string:

```javascript
TODO: 
1. Incorporate magmoms and vibrational frequencies.
2. Read constraints from POSCAR/CONTCAR to allow for
separation of vector constraints.
3. Fix alpha, beta, gamma code or remove completely.
4. Implement convergence check?
```

*Edit2:*
Validation for the ediff tag added