### PR TITLE
Simplification of the trajectory code

### DIFF
--- a/bin/vaspsum
+++ b/bin/vaspsum
@@ -32,6 +32,12 @@ parser.add_argument('dirs', nargs='*',
                     default = ['.'],
                     help='directories to summarize')
 
+parser.add_argument('-t', '--plot-trajectory', action='store_true',
+                    help = 'plot trajectory')
+
+parser.add_argument('-p', '--plot', action='store_true',
+                    help = 'plot in ag')
+
 args = parser.parse_args()
 
 if args.debug:
@@ -39,13 +45,20 @@ if args.debug:
 else:
     debug = None
 
-
 for d in args.dirs:
     if not os.path.isdir(d):
         raise Exception('{0} does not exist!'.format(d))
 
     calc = Vasp(d, debug=debug)
 
+    # plot trajectory
+    if args.plot_trajectory:
+        calc.view(index=None)
+
+    # plot final atoms image
+    if args.plot:
+        calc.view(index=-1)
+        
     if args.vasp:
         print(calc.vasp)
     elif args.json:

--- a/vasp/vasp_core.py
+++ b/vasp/vasp_core.py
@@ -772,16 +772,10 @@ class Vasp(FileIOCalculator, object):
             return tatoms
 
         LOA = []
-        i = 0
-        while True:
-            try:
-                atoms = read_vasp_xml(os.path.join(self.directory,
-                                                   'vasprun.xml'),
-                                      index=i).next()
-                LOA += [atoms]
-                i += 1
-            except IndexError:
-                break
+        for atoms in read_vasp_xml(os.path.join(self.directory,
+                                                'vasprun.xml'),
+                                   index=None):
+            LOA += [atoms]
         return LOA
 
     def view(self, index=None):


### PR DESCRIPTION
There is a feature in the existing ASE read_vasp_xml function which is not utilized to its full potential:
[https://gitlab.com/ase/ase/merge_requests/189](url)

The correction to the ASE code will allow the entire trajectory to be returned without use of the while loop in the vaspy traj function. I found the while loop to be dangerous when using it with the vaspsum -t parameter that is implemented in this pull request as well.

Only to be merged after the ASE merge request is finished.