### PR TITLE
trajectory can be read from xml with standard read

### DIFF
--- a/vasp/vasp_core.py
+++ b/vasp/vasp_core.py
@@ -13,7 +13,7 @@ import numpy as np
 import ase
 from ase.calculators.calculator import Calculator
 from ase.calculators.calculator import FileIOCalculator
-from ase.io.vasp import read_vasp_xml
+from ase.io import read
 
 # internal modules
 import exceptions
@@ -802,9 +802,7 @@ class Vasp(FileIOCalculator, object):
             return tatoms
 
         LOA = []
-        for atoms in read_vasp_xml(os.path.join(self.directory,
-                                                'vasprun.xml'),
-                                   index=None):
+        for atoms in read(os.path.join(self.directory, 'vasprun.xml'), ':'):
             LOA += [atoms]
         return LOA
 


### PR DESCRIPTION
The trajectory information can be read from the vasprun.xml file with the standard ase.io.read function. This prevent the need for changes in the ASE code.