### PR TITLE
Added write2db function

### DIFF
--- a/bin/runvasp.py
+++ b/bin/runvasp.py
@@ -18,6 +18,7 @@ if 'PBS_NODEFILE' in os.environ:
         # supports MPI. It used to support multiprocessing, but it was
         # confusing, so I have taken it out for now.
         parcmd = 'mpirun -np %i %s' % (NPROCS, parallel_vasp)
+        print('Running "{}"'.format(parcmd))
         exitcode = os.system(parcmd)
 else:
     # probably running at cmd line, in serial.

--- a/vasp/getters.py
+++ b/vasp/getters.py
@@ -193,7 +193,12 @@ def get_ados(self, atom_index, orbital, spin=1, efermi=None):
                      'set[@comment="ion {}"]',
                      'set[@comment="spin {}"]',
                      "r"])
-    path = path.format(self.resort.index(atom_index) + 1, spin)
+
+    us = [k[1] for k in
+          sorted([[j, i]
+                  for i, j in enumerate(self.resort)])]
+
+    path = path.format(us.index(atom_index) + 1, spin)
     log.debug(path)
 
     results = [[float(x) for x in el.text.split()]

--- a/vasp/readers.py
+++ b/vasp/readers.py
@@ -378,7 +378,7 @@ def read_results(self):
         self.results['forces'] = forces[self.resort]
         self.results['stress'] = stress
         self.results['dipole'] = None
-        self.results['charges'] = np.array([0 for atom in self.atoms])
+        self.results['charges'] = np.array([None for atom in self.atoms])
 
         magnetic_moment = 0
         magnetic_moments = np.zeros(len(atoms))

--- a/vasp/runner.py
+++ b/vasp/runner.py
@@ -200,7 +200,7 @@ runvasp.py     # this is the vasp command
     if out == '' or err != '':
         raise Exception('something went wrong in qsub:\n\n{0}'.format(err))
 
-    self.write_db(jobid=out.strip())
+    self.write_db(data={'jobid': out.strip()})
 
     raise VaspSubmitted('{} submitted: {}'.format(self.directory,
                                                   out.strip()))

--- a/vasp/runner.py
+++ b/vasp/runner.py
@@ -81,14 +81,6 @@ def calculate(self, atoms=None, properties=['energy'],
         log.debug('mode is None. not running')
         return
 
-    # not in queue. Delete the jobid
-    if self.get_db('jobid') is not None:
-        self.write_db(jobid=None)
-
-        # we should check for errors here.
-        self.read_results()
-        return
-
     if (not self.calculation_required(atoms, ['energy'])
         and not self.check_state()):
         print('No calculation_required.')

--- a/vasp/runner.py
+++ b/vasp/runner.py
@@ -257,7 +257,8 @@ def set_memory(self,
             FileIOCalculator.write_input(self, None, None, None)
             self.write_poscar()
             self.write_incar()
-            self.write_kpoints()
+            if 'kspacing' not in self.parameters:
+                self.write_kpoints()
             self.write_potcar()
 
             # Need to pass a function to Timer for delayed execution

--- a/vasp/validate.py
+++ b/vasp/validate.py
@@ -15,6 +15,18 @@ from ase.utils import basestring
 import warnings
 
 
+def algo(calc, val):
+    """ specify the electronic minimisation algorithm (as of VASP.4.5) (string)
+
+    http://cms.mpi.univie.ac.at/wiki/index.php/ALGO
+
+    """
+    assert isinstance(val, str)
+    assert val in ["Normal", "VeryFast", "Fast" , "Conjugate", "All", "Damped",
+                   "Subrot", "Eigenval", "None", "Nothing", "CHI", "GW0",
+                   "GW", "scGW0", "scGW"]
+
+
 def atoms(calc, val):
     """The Atoms object. (ase.atoms.Atoms or a list of them for an NEB)."""
     assert isinstance(val, ase.atoms.Atoms) or isinstance(val, list)
@@ -49,6 +61,22 @@ def encut(calc, val):
             or isinstance(val, float)),\
         ('encut should be an int or float.'
          ' You provided {} ({}).'.format(val, type(val)))
+
+
+def ialgo(calc, val):
+    """IALGO selects the algorithm used to optimize the orbitals. (int)
+
+    http://cms.mpi.univie.ac.at/wiki/index.php/IALGO
+
+    """
+    print('You are advised to use the algo key instead of ialgo.')
+    assert isinstance(val, int)
+    assert val in [-1, 2, 3, 4, 5, 6, 7, 8,
+                   15, 16, 17, 18,
+                   28,
+                   38,
+                   44, 45, 46, 47, 48,
+                   53, 54, 55, 56, 57, 58]
 
 
 def ibrion(calc, val):
@@ -212,6 +240,14 @@ def kpts_nintersections(calc, val):
     assert isinstance(val, int)
 
 
+def kspacing(calc, val):
+    """KSPACING determines the number of k-points if the KPOINTS file is not present (float).
+
+    http://cms.mpi.univie.ac.at/vasp/vasp/KSPACING_tag_KGAMMA_tag.html
+    """
+    assert(isinstance(val, float))
+
+
 def lcharg(calc, val):
     """LCHARG determines whether CHGCAR and CHG are written. (boolean)
 
@@ -230,6 +266,15 @@ def lorbit(calc, val):
     if val < 10:
         assert 'rwigs' in calc.parameters
     assert isinstance(val, int)
+
+
+def lreal(calc, val):
+    """LREAL determines whether the projection operators are evaluated in real-space or in reciprocal space. (boolean)
+
+    http://cms.mpi.univie.ac.at/wiki/index.php/LREAL
+
+    """
+    assert val in [True, False, 'On', 'Auto', 'O', 'A']
 
 
 def lwave(calc, val):
@@ -264,6 +309,15 @@ def nbands(calc, val):
     s = 'nbands = {} which is less than {}.'
     assert val > calc.get_valence_electrons() / 2, \
         s.format(val, calc.get_valence_electrons() / 2)
+
+
+def nelm(calc, val):
+    """NELM sets the maximum number of electronic SC (selfconsistency) steps which may be performed. (int)
+
+    http://cms.mpi.univie.ac.at/wiki/index.php/NELM
+    """
+
+    assert isinstance(val, int)
 
 
 def nupdown(calc, val):

--- a/vasp/vasp_core.py
+++ b/vasp/vasp_core.py
@@ -409,7 +409,7 @@ class Vasp(FileIOCalculator, object):
             from ase.db import connect
             with connect(os.path.join(self.directory, 'DB.db')) as con:
                 tatoms = con.get_atoms(id=1)
-            self.write_db(tatoms, data={'resort': ns})
+            self.write_db(atoms=tatoms, data={'resort': ns})
             print('Fixed resort issue in {}. '
                   'You should not see this message'
                   ' again'.format(self.directory))
@@ -747,8 +747,8 @@ class Vasp(FileIOCalculator, object):
             # eliminate jobid on copying.
             newdb = os.path.join(newdir, 'DB.db')
             self.write_db(fname=newdb,
-                          path=os.path.abspath(newdir),
-                          jobid=None)
+                          data={'path': os.path.abspath(newdir),
+                                'jobid': None})
 
         self.__init__(newdir)
 

--- a/vasp/vasp_core.py
+++ b/vasp/vasp_core.py
@@ -758,13 +758,14 @@ class Vasp(FileIOCalculator, object):
         Returns an integer for the state.
 
         """
-
+        # We do not check for KPOINTS here. That file may not exist if
+        # the kspacing incar parameter is used.
         base_input = [os.path.exists(os.path.join(self.directory, f))
-                      for f in ['INCAR', 'POSCAR', 'POTCAR', 'KPOINTS']]
+                       for f in ['INCAR', 'POSCAR', 'POTCAR']]
 
         # Check for NEB first.
         if (np.array([os.path.exists(os.path.join(self.directory, f))
-                      for f in ['INCAR', 'POTCAR', 'KPOINTS']]).all()
+                      for f in ['INCAR', 'POTCAR']]).all()
             and not os.path.exists(os.path.join(self.directory, 'POSCAR'))
             and os.path.isdir(os.path.join(self.directory, '00'))):
             return Vasp.NEB

--- a/vasp/vasp_core.py
+++ b/vasp/vasp_core.py
@@ -56,7 +56,7 @@ class Vasp(FileIOCalculator, object):
     $VASP_PP_PATH/potpaw_GGA
 
     """
-    version = "0.9.1"
+    version = "0.9.2"
     name = 'VASP'
     command = None
     debug = None
@@ -411,7 +411,8 @@ class Vasp(FileIOCalculator, object):
                 tatoms = con.get_atoms(id=1)
             self.write_db(tatoms, data={'resort': ns})
             print('Fixed resort issue in {}. '
-                  'You should not see this message again'.format(self.directory))
+                  'You should not see this message'
+                  ' again'.format(self.directory))
             self.resort = ns
             sort_indices = [k[1] for k in
                             sorted([[j, i]
@@ -423,7 +424,6 @@ class Vasp(FileIOCalculator, object):
                               else atoms[x[0]].symbol,
                               x[2]) for x in ppp]
 
-        #return atoms[sort_indices]
 
     def _repr_html_(self):
         """Output function for Jupyter notebooks."""

--- a/vasp/writers.py
+++ b/vasp/writers.py
@@ -113,12 +113,6 @@ def write_db(self,
                  'parameters': self.parameters,
                  'ppp_list': self.ppp_list})
 
-    # Add calculation time to key-value-pairs
-    try:
-        data['ctime'] = float(self.get_elapsed_time())
-    except(AttributeError, IOError):
-        data['ctime'] = float(0.0)
-
     # Only relevant for writing single entry DB file.
     if overwrite:
 
@@ -129,7 +123,7 @@ def write_db(self,
                     dbatoms = db.get_atoms(id=1)
                     data.update(dbatoms.data)
                     keys.update(dbatoms.key_value_pairs)
-                except KeyError:
+                except AttributeError:
                     pass
             os.unlink(fname)
 

--- a/vasp/writers.py
+++ b/vasp/writers.py
@@ -22,7 +22,8 @@ def write_input(self, atoms=None, properties=None, system_changes=None):
     if 'spring' not in self.parameters:  # do not write if NEB
         self.write_poscar()
     self.write_incar()
-    self.write_kpoints()
+    if 'kspacing' not in self.parameters:
+        self.write_kpoints()
     self.write_potcar()
     self.write_db()
 


### PR DESCRIPTION
Hi John,

I'm unsure whether the following function should be separated from  the current "write_db" function, or not. "write_db" seems specifically tailored for manipulations in a 1 entry database, so I opted to make a separate function for this, although both are very similar and could conceivably be made one function.

I would like to incorporate a database writing function into vaspy with the following:

1. Parsing for key-value-pairs from the directory name.
2. Calculators separate from atoms objects so an identical calculator can be attached to multiple trajectory images.
3. Room to easily incorporate other types of commonly used data, such as DOS, ADOS, or BEEF ensembles. 

Here's an example of how this would work:

EDIT: function merged with existing write_db function.

```python
from ase.lattice.cubic import FaceCenteredCubic as fcc
from vasp import Vasp
from vasp.vasprc import VASPRC
import numpy as np
VASPRC['queue.walltime'] = '24:00:00'

atoms = fcc('Pd',
            directions=[[0, 1, 1],
                        [1, 0, 1],
                        [1, 1, 0]])

# We will sample a large range of energy cutoffs
calcs = [Vasp('DFT/bulk=fcc/conv=encut/encut={}'.format(k),
              xc='pbe',
              kpts=[16]*3,
              encut=k,
              nsw=0,
              atoms=atoms)
         for k in np.arange(300, 1050, 50)]
nrg = [calc.potential_energy for calc in calcs]
Vasp.stop_if(None in nrg)

# Write all entries to database
[calc.write_db('DFT.db', parser='=', overwrite=False) for calc in calcs]
```