### PR TITLE
corrected special setups behavior when indexing specific atoms

### DIFF
--- a/vasp/setters.py
+++ b/vasp/setters.py
@@ -41,7 +41,7 @@ def set(self, **kwargs):
     changed_parameters = FileIOCalculator.set(self, **kwargs)
 
     # If we are implementing special setups, the ppp_list needs
-    # to be updated so he POSCAR and POTCAR can be written correctly.
+    # to be updated so the POSCAR and POTCAR can be written correctly.
     if 'setups' in changed_parameters.keys():
         self.sort_atoms(self.atoms)
 

--- a/vasp/setters.py
+++ b/vasp/setters.py
@@ -40,6 +40,11 @@ def set(self, **kwargs):
 
     changed_parameters = FileIOCalculator.set(self, **kwargs)
 
+    # If we are implementing special setups, the ppp_list needs
+    # to be updated so he POSCAR and POTCAR can be written correctly.
+    if 'setups' in changed_parameters.keys():
+        self.sort_atoms(self.atoms)
+
     # we don't consider None values to be changed if the keyword was
     # not originally in the parameters.
     cp = {k: v for k, v in changed_parameters.iteritems()

--- a/vasp/vasp_core.py
+++ b/vasp/vasp_core.py
@@ -345,9 +345,8 @@ class Vasp(FileIOCalculator, object):
 
         # First the numeric index setups
         for setup in [x for x in setups if isinstance(x[0], int)]:
-            ppp += [[setup[0],
-                     'potpaw_{}/{}{}/POTCAR'.format(pp, atoms[setup[0]].symbol,
-                                                    setup[1]),
+            ppp += [[setup[1],
+                     'potpaw_{}/{}/POTCAR'.format(pp, setup[1]),
                      1]]
             sort_indices += [setup[0]]
 
@@ -367,8 +366,7 @@ class Vasp(FileIOCalculator, object):
         # First get the chemical symbols that remain
         symbols = []
         for atom in atoms or []:
-            if (atom.symbol not in symbols and
-                atom.symbol not in [x[0] for x in ppp]):
+            if atom.symbol not in symbols:
                 symbols += [atom.symbol]
 
         for symbol in symbols:

--- a/vasp/vasp_core.py
+++ b/vasp/vasp_core.py
@@ -685,39 +685,6 @@ class Vasp(FileIOCalculator, object):
                 if 'Voluntary context switches:' in lines[-1]:
                     return False
 
-    def calculate(self, atoms=None, properties=['energy'],
-                  system_changes=None):
-        """Runs a calculation, only if necessary."""
-        if self.calculation_required(atoms, properties):
-
-            # The subclass implementation should first call this
-            # implementation to set the atoms attribute.
-            Calculator.calculate(self, atoms, properties, system_changes)
-
-            self.write_input(atoms, properties, system_changes)
-
-            if self.command is None:
-                raise RuntimeError('Please set $%s environment variable ' %
-                                   ('ASE_' + self.name.upper() + '_COMMAND') +
-                                   'or supply the command keyword')
-
-            olddir = os.getcwd()
-            try:
-                os.chdir(self.directory)
-                errorcode = subprocess.call(self.command,
-                                            stdout=subprocess.PIPE,
-                                            shell=True)
-
-            finally:
-                os.chdir(olddir)
-
-            if errorcode:
-                s = '{} returned an error: {}'
-                raise RuntimeError(s.format(self.name, errorcode))
-
-        # This sets self.results, and updates the atoms
-        self.read_results()
-
     def clone(self, newdir):
         """Copy the calculation directory to newdir and set label to
         newdir.

--- a/vasp/vasp_core.py
+++ b/vasp/vasp_core.py
@@ -422,7 +422,6 @@ class Vasp(FileIOCalculator, object):
                               else atoms[x[0]].symbol,
                               x[2]) for x in ppp]
 
-
     def _repr_html_(self):
         """Output function for Jupyter notebooks."""
         from ase.io import write


### PR DESCRIPTION
John,

Theses changes will ensure that the POTCAR and POSCAR files are written correctly for setting up calculations with special setups for indexed atoms. This patch only fixes CLS calculations started with a fresh calculator. For example, this will work:

```python
from vasp import Vasp
from ase import Atom, Atoms
Vasp.VASPRC['queue.walltime'] = '24:00:00'

atoms = Atoms([Atom('Cu',  [0.000,      0.000,      0.000]),
               Atom('Cu',  [-1.652,     0.000,      2.039])],
              cell=  [[0.000, -2.039,  2.039],
                      [0.000,  2.039,  2.039],
                      [-3.303,  0.000,  0.000]])

atoms = atoms.repeat((2, 2, 2))

calc = Vasp('bulk/Cu-cls-0',
            xc='PBE',
            encut=350,
            kpts=[4, 4, 4],
            ibrion=2,
            isif=3,
            nsw=40,
            atoms=atoms)
print(atoms.get_potential_energy())
```

```python
from vasp import Vasp
from ase.io import read

atoms = read('bulk/Cu-cls-0/CONTCAR')

calc = Vasp('bulk/Cu-cls-2',
            xc='PBE',
            encut=350,
            kpts=[4, 4, 4],
            ibrion=2,
            isif=3,
            nsw=40,
            setups=[[0, 'Cu']],  # Create separate entry in POTCAR for atom index 0
            icorelevel=2,        # Perform core level shift calculation
            clnt=0,              # Excite atom index 0
            cln=2,               # 2p3/2 electron for Cu core level shift
            cll=1,
            clz=1,
            atoms=atoms)

print(atoms.get_potential_energy())
```

However, if you an attempt an update such as is done in the DFT book, you will get no error but an incorrect calculation.

```python
from vasp import Vasp

calc = Vasp('bulk/Cu-cls-0')
calc.clone('bulk/Cu-cls-41')

calc.set(ibrion=None,
         isif=None,
         nsw=None,
         setups=[[0, 'Cu']],  # Create separate entry in POTCAR for atom index 0
         icorelevel=2,        # Perform core level shift calculation
         clnt=0,              # Excite atom index 0
         cln=2,               # 2p3/2 electron for Cu core level shift
         cll=1,
         clz=1,)
calc.update()
```

Adding the setup tag needs to trigger a rewrite of the POSCAR and POTCAR files somewhere. Finding out exactly where this needs to be done is difficult since the set and update functions seem to be called multiple times when running the block above. Some of the variable in these functions don't seem to work as they suggest either. I'll look at it again this weekend.